### PR TITLE
Remove rdflib dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,6 @@ pygments==2.3.1  # ipython
 scandir==1.10.0  # ipython
 ipython==7.3.0
 ipdb==0.11
-rdflib==4.2.2
 coverage==4.5.3
 pyasn1==0.4.5
 cryptography==2.6.1  # pyOpenSSL


### PR DESCRIPTION
Pyup reports a security vulnerability with this library. The dependency was added around iPython / coverage over 6 years ago. Removing has no effect in my local dev environment. I'm going to try pulling it and see if anything breaks.