### PR TITLE
Mobile: search results scrolling issue

### DIFF
--- a/media/css/coming-soon.css
+++ b/media/css/coming-soon.css
@@ -13,6 +13,7 @@ body {
     -moz-background-size: cover;
     -o-background-size: cover;
     background-size: cover;
+    min-height: 45rem;
 }
 
 .masthead {

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -6,7 +6,7 @@ html, body {
     font-family: Open Sans;
 }
 
-body, main {
+body.flatpage {
   min-height: 45rem;
 }
 


### PR DESCRIPTION
don't specify a min-height on the map page.