### PR TITLE
Admissions url: don't display when blank

### DIFF
--- a/ahemap/templates/clientside/google_map_template.html
+++ b/ahemap/templates/clientside/google_map_template.html
@@ -152,11 +152,11 @@
                         </a>
                         <div class="d-none d-print-block"><i class="fas fa-link"></i> {{selectedSite.website_url}}</div>
                     </div>
-                    <div v-if="selectedSite.website_url" class="float-right">
+                    <div v-if="selectedSite.admissions_url" class="float-right">
                         <a class="d-print-none" :href="selectedSite.admissions_url"
                             title="Selected school veterans admissions link"
                             target="about:blank">
-                            <i class="fas fa-link"></i> Veterans Admissions
+                            <i class="fas fa-link"></i> Admissions
                         </a>
                         <div class="d-none d-print-block"><i class="fas fa-link"></i> {{selectedSite.website_url}}</div>
                     </div>

--- a/ahemap/templates/main/institution_detail.html
+++ b/ahemap/templates/main/institution_detail.html
@@ -84,17 +84,19 @@
                                 <li>Four-year program</li>
                             {% endif %}{% endif %}{% endif %}
                             <li>
-                                <a class="d-print-none" href="{{object.website_url}}" title="website link" target="_blank" rel="noopener">
-                                    Website Link
+                                <a class="d-print-none" href="{{object.website_url}}" title="Website" target="_blank" rel="noopener">
+                                    Website
                                 </a>
                                 <span class="d-none d-print-inline">{{object.website_url}}</span>
                             </li>
+                            {% if object.admissions_url %}
                             <li>
-                                <a class="d-print-none" href="{{object.admissions_url}}" title="veterans adminissions link" target="_blank" rel="noopener">
-                                    Admissions Link
+                                <a class="d-print-none" href="{{object.admissions_url}}" title="Admissions" target="_blank" rel="noopener">
+                                    Admissions
                                 </a>
                                 <span class="d-none d-print-inline">{{object.admissions_url}}</span>
                             </li>
+                            {% endif %}
                         </ul>
                     </div>
                     <div class="col-md-6">


### PR DESCRIPTION
and make the link names consistent.