### PR TITLE
Safari: sr-only absolute positioning renders incorrectly

### DIFF
--- a/ahemap/templates/main/institution_detail.html
+++ b/ahemap/templates/main/institution_detail.html
@@ -211,7 +211,7 @@
                     <div>Maximum Contribution (per student/per year): {{object.yellow_ribbon_contribution}}.</div>
                 {% endif %}
 
-                <div class="sr-only">
+                <div class="custom-sr-only">
                     <h3>Accepted Credits</h3>
                     {% if object.clep_credits_accepted %}
                         CLEP credits are accepted.
@@ -270,7 +270,7 @@
 
                 {% if object.notes %}
                 <h2 class="mt-4">Additional Information</h2>
-                <div>{{object.notes|safe|urlize|url_target_blank}}</div>
+                <div class="overflow-auto">{{object.notes|safe|urlize|url_target_blank}}</div>
                 {% endif %}
 
                 <h2 class="mt-4">Location</h2>

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -48,6 +48,17 @@ a {
     outline: 1px dotted;
 }
 
+.custom-sr-only {
+    /* position: absolute; << Safari doesn't like this */
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+}
+
 /* Navbar */
 .navbar {
     padding: 0;


### PR DESCRIPTION
I'm guessing that the height of the div is being calculated incorrectly.
In any event, removing the absolute positioning resolves the issue, and
imho is not really needed.