### PR TITLE
Handle null bytes in query strings

### DIFF
--- a/ahemap/main/tests/test_utils.py
+++ b/ahemap/main/tests/test_utils.py
@@ -1,0 +1,16 @@
+from django.test import TestCase
+from ahemap.main.utils import sanitize, validate_state
+
+
+class UtilsTest(TestCase):
+
+    def test_sanitize(self):
+        self.assertEquals(sanitize('s\0s'), '')
+        self.assertEquals(sanitize('\x00s\x00s'), '')
+        self.assertEquals(sanitize('s\0s\x00'), '')
+        self.assertEquals(sanitize('query'), 'query')
+
+    def test_validate_state(self):
+        self.assertFalse(validate_state(''))
+        self.assertFalse(validate_state('NYC'))
+        self.assertTrue(validate_state('NY'))

--- a/ahemap/main/tests/test_views.py
+++ b/ahemap/main/tests/test_views.py
@@ -43,6 +43,20 @@ class BrowseViewTest(TestCase):
         self.assertEquals(response.context_data['population'], '')
         self.assertEquals(response.context_data['query'], '')
 
+    def test_get_null_bytes(self):
+        params = ('fouryear=true&populationdata=&private=true&public=true'
+                  '&q=%00&state=data&twoyear=trye')
+        url = '{}?{}'.format(reverse('browse-view'), params)
+        response = self.client.get(url)
+        self.assertEquals(response.status_code, 200)
+        self.assertEquals(response.context_data['twoyear'], 'trye')
+        self.assertEquals(response.context_data['fouryear'], 'true')
+        self.assertEquals(response.context_data['public'], 'true')
+        self.assertEquals(response.context_data['private'], 'true')
+        self.assertEquals(response.context_data['state'], 'data')
+        self.assertEquals(response.context_data['population'], '')
+        self.assertEquals(response.context_data['query'], '\x00')
+
 
 class InstitutionViewSetTest(TestCase):
 

--- a/ahemap/main/utils.py
+++ b/ahemap/main/utils.py
@@ -1,3 +1,6 @@
+from html import escape
+import re
+
 from rest_framework.renderers import BrowsableAPIRenderer
 
 
@@ -20,3 +23,13 @@ class BrowsableAPIRendererNoForms(BrowsableAPIRenderer):
         rendered HTML, so let's simply return an empty string.
         """
         return ""
+
+
+def sanitize(s):
+    if s and '\0' not in s and '\x00' not in s:
+        return escape(s)
+    return ''
+
+
+def validate_state(s):
+    return re.match('^[A-Z][A-Z]$', s) is not None

--- a/ahemap/main/utils.py
+++ b/ahemap/main/utils.py
@@ -1,4 +1,4 @@
-from html import escape
+from django.utils.html import escape
 import re
 
 from rest_framework.renderers import BrowsableAPIRenderer

--- a/ahemap/main/views.py
+++ b/ahemap/main/views.py
@@ -1,21 +1,20 @@
 import csv
 from urllib.parse import urlencode
 
+from ahemap.main.forms import InstitutionImportForm
+from ahemap.main.models import Institution
+from ahemap.main.serializers import InstitutionSerializer
+from ahemap.main.utils import sanitize, validate_state
 from django.conf import settings
 from django.contrib import messages
 from django.db import transaction
 from django.http.response import StreamingHttpResponse
 from django.urls.base import reverse
-from django.utils.html import escape
 from django.views.generic.base import TemplateView, View
 from django.views.generic.detail import DetailView
 from django.views.generic.edit import FormView
 from django.views.generic.list import ListView
 from rest_framework import viewsets
-
-from ahemap.main.forms import InstitutionImportForm
-from ahemap.main.models import Institution
-from ahemap.main.serializers import InstitutionSerializer
 
 
 # returns important setting information for all web pages.
@@ -114,20 +113,23 @@ class InstitutionSearchMixin(object):
 
     def filter_by_state(self, qs, params):
         q = params.get('state', None)
-        if q:
+        q = sanitize(q)
+        if q and validate_state(q):
             qs = qs.filter(state=q)
         return qs
 
     def filter_by_name(self, qs, params):
         # filter by a search term
         q = params.get('q', None)
+        q = sanitize(q)
         if q:
-            qs = qs.filter(title__icontains=escape(q))
+            qs = qs.filter(title__icontains=q)
 
         return qs
 
     def filter_by_site(self, qs, params):
         site = params.get('siteid', None)
+        site = sanitize(site)
         if site:
             qs = qs.filter(id=site)
         return qs


### PR DESCRIPTION
Addressing an input sanitization issue that appeared during vulnerability scans. Some text-based parameters were not being fully sanitized for null bytes. (escape was used to catch most injection issues.)

There’s actually little harm in this – the Django ORM rejects the special characters and throws an exception. But I’ve added additional logic here to handle the situation more gracefully.

Django actually prohibits null characters via its form field validators by default now: https://code.djangoproject.com/ticket/28201