### PR TITLE
Add yellow ribbon search criteria

### DIFF
--- a/ahemap/main/tests/test_views.py
+++ b/ahemap/main/tests/test_views.py
@@ -42,6 +42,7 @@ class BrowseViewTest(TestCase):
         self.assertEquals(response.context_data['state'], '')
         self.assertEquals(response.context_data['population'], '')
         self.assertEquals(response.context_data['query'], '')
+        self.assertEquals(response.context_data['yellowribbon'], '')
 
     def test_get_null_bytes(self):
         params = ('fouryear=true&populationdata=&private=true&public=true'
@@ -56,6 +57,7 @@ class BrowseViewTest(TestCase):
         self.assertEquals(response.context_data['state'], 'data')
         self.assertEquals(response.context_data['population'], '')
         self.assertEquals(response.context_data['query'], '\x00')
+        self.assertEquals(response.context_data['yellowribbon'], '')
 
 
 class InstitutionViewSetTest(TestCase):
@@ -101,6 +103,25 @@ class InstitutionViewSetTest(TestCase):
         self.assertEquals(the_json[0]['id'], self.inst1.id)
 
         url = '/api/institution/?twoyear=true&fouryear=true'
+        response = self.client.get(url)
+        self.assertEquals(response.status_code, 200)
+        the_json = loads(response.content.decode('utf-8'))
+        self.assertEquals(len(the_json), 2)
+        self.assertEquals(the_json[0]['id'], self.inst1.id)
+        self.assertEquals(the_json[1]['id'], self.inst2.id)
+
+    def test_filter_yellow_ribbon(self):
+        self.inst2.yellow_ribbon = False
+        self.inst2.save()
+
+        url = '/api/institution/?yellowribbon=true'
+        response = self.client.get(url)
+        self.assertEquals(response.status_code, 200)
+        the_json = loads(response.content.decode('utf-8'))
+        self.assertEquals(len(the_json), 1)
+        self.assertEquals(the_json[0]['id'], self.inst1.id)
+
+        url = '/api/institution/?yellowribbon='
         response = self.client.get(url)
         self.assertEquals(response.status_code, 200)
         the_json = loads(response.content.decode('utf-8'))

--- a/ahemap/main/views.py
+++ b/ahemap/main/views.py
@@ -78,6 +78,12 @@ class InstitutionImportView(FormView):
 
 class InstitutionSearchMixin(object):
 
+    def filter_by_yellow_ribbon(self, qs, params):
+        yellow_ribbon = params.get('yellowribbon', 'false') in ['true', 'on']
+        if yellow_ribbon:
+            return qs.filter(yellow_ribbon=True)
+        return qs
+
     def filter_by_duration(self, qs, params):
         two = params.get('twoyear', 'false') == 'true'
         four = params.get('fouryear', 'false') == 'true'
@@ -148,6 +154,7 @@ class InstitutionSearchMixin(object):
         qs = self.filter_by_state(qs, params)
         qs = self.filter_by_name(qs, params)
         qs = self.filter_by_site(qs, params)
+        qs = self.filter_by_yellow_ribbon(qs, params)
         return qs
 
 
@@ -171,6 +178,7 @@ class BrowseView(InstitutionSearchMixin, ListView):
             'private': self.request.GET.get('private', 'false'),
             'population': self.request.GET.get('population', ''),
             'state': self.request.GET.get('state', ''),
+            'yellowribbon': self.request.GET.get('yellowribbon', '')
         }
 
         context.update(ctx)

--- a/ahemap/templates/clientside/google_map_template.html
+++ b/ahemap/templates/clientside/google_map_template.html
@@ -20,7 +20,7 @@
                     </span>
                 </div>
                 <div class="search-criteria collapse show px-3 pb-4">
-                    <i class="fa fa-graduation-cap text-muted" aria-hidden="true"></i> Type
+                    <i class="fa fa-random text-muted" aria-hidden="true"></i> Type
                     <span class="float-right">
                         <span class="form-check form-check-inline">
                             <input v-model="schoolPublic" class="form-check-input" type="checkbox"
@@ -34,7 +34,7 @@
                         </span>
                     </span>
                 </div>
-                <div class="search-criteria collapse show px-3 pb-4">
+                <div class="clearfix search-criteria collapse show px-3 pb-4">
                     <i aria-hidden="true" class="fas fa-users text-muted"></i>
                     <label for="populations">Size</label>
                     <span class="undergraduate-populations float-right">
@@ -54,7 +54,6 @@
                         </multiselect>
                     </span>
                 </div>
-
                 <div class="search-criteria collapse show px-3 pb-4">
                     <i aria-hidden="true" class="fas fa-map-marked-alt text-muted"></i>
                     <label for="states">State</label>
@@ -68,7 +67,7 @@
                         </multiselect>
                     </span>
                 </div>
-                <div class="search-criteria collapse show px-3">
+                <div class="search-criteria collapse show px-3 pb-4">
                     <i class="fas fa-landmark text-muted"></i>
                     <label for="search-term">Name</label>
                     <div class="search-bar float-right">
@@ -88,7 +87,18 @@
                         </div>
                     </div>
                 </div>
-                <div class="clearfix"></div>
+                <div class="search-criteria collapse show px-3 pb-3 clearfix">
+                    <div class="float-left">
+                        <i class="fa fa-graduation-cap text-muted" aria-hidden="true"></i> Yellow-Ribbon Grant
+                    </div>
+                    <div class="float-right">
+                        <div class="custom-control custom-switch custom-switch-md">
+                            <input v-model="yellowRibbon" name="yellowribbon" type="checkbox"
+                                class="custom-control-input" id="yellow-ribbon-grant">
+                            <label aria-hidden="true" class="custom-control-label" for="yellow-ribbon-grant"></label>
+                        </div>
+                    </div>
+                </div>
                 <div class="advanced-filter-toggle small bg-light px-2 py-1 text-black"
                     data-toggle="collapse" href="#collapseExample" role="button"
                     data-target=".search-criteria"
@@ -127,6 +137,7 @@
                     <input name="state" :value="state ? state.id : ''" type="hidden" />
                     <input name="population" :value="population ? population.id : ''" type="hidden" />
                     <input name="q" :value="searchTerm" type="hidden" />
+                    <input name="yellowribbon" :value="yellowRibbon" type="hidden" />
                     <button v-if="selectedSite || searchResults"
                         class="btn btn-sm btn-link float-right text-white w-50"
                         title="Save Search Results">
@@ -193,6 +204,7 @@
                     <input name="state" :value="state ? state.id : ''" type="hidden" />
                     <input name="population" :value="population ? population.id : ''" type="hidden" />
                     <input name="q" :value="searchTerm" type="hidden" />
+                    <input name="yellowribbon" :value="yellowRibbon" type="hidden" />
                     <button v-if="selectedSite || (searchResults && searchResults.length > 1)"
                         class="btn btn-sm btn-link float-right text-white w-50"
                         title="Save Search Results">

--- a/ahemap/templates/main/institution_list.html
+++ b/ahemap/templates/main/institution_list.html
@@ -34,7 +34,7 @@
                     <span class="ml-1 float-right">
                         <span class="form-check form-check-inline">
                             <input class="form-check-input" type="checkbox"
-                                id="two-year-program" name="twoyear" value="trye"
+                                id="two-year-program" name="twoyear" value="true"
                                 {% if twoyear == "true" %}checked="checked"{% endif %}>
                             <label class="form-check-label" for="two-year-program">2-year</label>
                         </span>
@@ -48,7 +48,7 @@
                 </div>
                 <div class="search-criteria px-3 pb-4">
                     <span class="search-criteria-label">
-                        <i class="fa fa-graduation-cap text-muted" aria-hidden="true"></i> Type
+                        <i class="fa fa-random text-muted" aria-hidden="true"></i> Type
                     </span>
                     <span class="ml-1 float-right">
                         <span class="form-check form-check-inline">
@@ -119,6 +119,19 @@
                                 {% if query %}value="{{query}}"{% endif %}>
                         </div>
                     </span>
+                </div>
+                <div class="search-criteria px-3 clearfix">
+                    <div class="float-left">
+                        <i class="fa fa-graduation-cap text-muted" aria-hidden="true"></i> Yellow-Ribbon Grant
+                    </div>
+                    <div class="float-right">
+                        <div class="custom-control custom-switch custom-switch-md">
+                            <input name="yellowribbon" type="checkbox" value="true"
+                                {% if yellowribbon == "true" %}checked="checked"{% endif %}
+                                class="custom-control-input" id="yellow-ribbon-grant">
+                            <label aria-hidden="true" class="custom-control-label" for="yellow-ribbon-grant"></label>
+                        </div>
+                    </div>
                 </div>
                 <div class="p-3 text-right">
                     <button type="reset" name="reset" class="btn btn-light" @click="clearSearch">

--- a/media/css/main.css
+++ b/media/css/main.css
@@ -568,7 +568,7 @@ span.states {
     }
     .map-view .pin-place-detail {
         width: 24rem;
-        top: 18.25rem;
+        top: 21.25rem;
         left: 0.625rem;
         right: 0;
         bottom: auto;
@@ -769,4 +769,33 @@ span.states {
     .print-header h5 a {
         font-family: Georgia,Times,Times New Roman,serif !important;
     }
+}
+
+
+/* Larger Switch */
+/* https://stackoverflow.com/questions/60406849/
+   how-to-style-switch-for-different-classes-in-bootstrap-4 */
+.custom-switch.custom-switch-md {
+    margin-top: -4px;
+}
+
+.custom-switch.custom-switch-md .custom-control-label {
+    padding-left: .5rem;
+    padding-bottom: 1.5rem;
+}
+
+.custom-switch.custom-switch-md .custom-control-label::before {
+    height: 1.5rem;
+    width: calc(2rem + 0.75rem);
+    border-radius: 3rem;
+}
+
+.custom-switch.custom-switch-md .custom-control-label::after {
+    width: calc(1.5rem - 4px);
+    height: calc(1.5rem - 4px);
+    border-radius: calc(2rem - (1.5rem / 2));
+}
+
+.custom-switch.custom-switch-md .custom-control-input:checked ~ .custom-control-label::after {
+    transform: translateX(calc(1.5rem - 0.25rem));
 }

--- a/media/js/src/components/gmapvue.js
+++ b/media/js/src/components/gmapvue.js
@@ -21,7 +21,8 @@ define(libs, function($, multiselect, markerclusterer, utils) {
                 schoolPublic: null,
                 schoolPrivate: null,
                 twoYear: null,
-                fourYear: null
+                fourYear: null,
+                yellowRibbon: null
             };
         },
         methods: {
@@ -53,6 +54,7 @@ define(libs, function($, multiselect, markerclusterer, utils) {
                 this.population = null;
                 this.state = null;
                 this.searchTerm = null;
+                this.yellowRibbon = null;
 
                 $('#two-year-program').focus();
                 window.history.replaceState({}, '', '/map/');
@@ -148,6 +150,9 @@ define(libs, function($, multiselect, markerclusterer, utils) {
                 if (this.searchTerm) {
                     params['q'] = utils.sanitize(this.searchTerm);
                 }
+                if (this.yellowRibbon) {
+                    params['yellowribbon'] = this.yellowRibbon;
+                }
                 return params;
             },
             search: function(criteria) {
@@ -197,6 +202,9 @@ define(libs, function($, multiselect, markerclusterer, utils) {
                 if (this.population) {
                     url += '&population=' + this.population.id;
                 }
+                if (this.yellowRibbon) {
+                    url += '&yellowribbon=' + this.yellowRibbon;
+                }
                 return $.getJSON(url);
             },
             siteResults: function(results) {
@@ -245,6 +253,9 @@ define(libs, function($, multiselect, markerclusterer, utils) {
                 }
                 if ('private' in params) {
                     this.schoolPrivate = params['private'] === 'true';
+                }
+                if ('yellowribbon' in params) {
+                    this.yellowRibbon = params['yellowribbon'] === 'true';
                 }
                 if ('population' in params && params.population) {
                     for (let p of this.populations) {
@@ -358,6 +369,7 @@ define(libs, function($, multiselect, markerclusterer, utils) {
                 this.$watch('schoolPrivate', this.onChangeCriteria);
                 this.$watch('state', this.onChangeCriteria);
                 this.$watch('population', this.onChangeCriteria);
+                this.$watch('yellowRibbon', this.onChangeCriteria);
             });
         },
         updated: function() {

--- a/media/js/src/utils.js
+++ b/media/js/src/utils.js
@@ -111,8 +111,7 @@ define(function() {
         }
 
         return viewportheight -
-            (8 +
-             jQuery('.advanced-filters').offset().top +
+            (10 + jQuery('.advanced-filters').offset().top +
              jQuery('.advanced-filters').outerHeight());
     }
 


### PR DESCRIPTION
Add the Yellow-Ribbon Program to the search forms using the Bootstrap switch control. If the switch is on, only Yellow Ribbon schools are displayed. If the switch is off, the Yellow Ribbon criteria is not considered.

<img width="395" alt="Screen Shot 2020-12-17 at 7 10 00 PM" src="https://user-images.githubusercontent.com/141369/102558482-84f9bd00-409b-11eb-8d71-7247d4749d37.png">
