### PR TITLE
Fix typo in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -99,5 +99,5 @@ distro==1.7.0
 typing_extensions==4.1.1
 
 python-cas==1.6.0
-django-cas-ng===4.3.0
+django-cas-ng==4.3.0
 asgiref==3.4.1


### PR DESCRIPTION
This should be double equals. But I guess triple equals still works?